### PR TITLE
Add additional options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,18 @@ the set of files returned:
 
 ```js
 var walkSync = require('walk-sync');
+
+// all files and directories contained within
+var paths = walkSync('project');
+
+// only files and directories matching the provided globs
 var paths = walkSync('project', ['lib/**/*.js', '*.md']);
+
+// only files matching the provided globs
+var paths = walkSync('project', {
+  glob: ['lib/**/*.js', '*.md'],
+  directories: false // default true
+});
 ```
 
 Given files `project/lib/main.js`, `project/README.md`, and

--- a/test/test.js
+++ b/test/test.js
@@ -56,6 +56,10 @@ test('walkSync \w matchers', function (t) {
      'dir/bar.txt'
    ])
 
+   t.deepEqual(walkSync('test/fixtures', { globs: ['dir/bar.txt'] }), [
+     'dir/bar.txt'
+   ]);
+
    t.deepEqual(walkSync('test/fixtures', ['dir/bar.txt', 'dir/zzz.txt']), [
      'dir/bar.txt',
      'dir/zzz.txt'
@@ -69,6 +73,16 @@ test('walkSync \w matchers', function (t) {
    t.deepEqual(walkSync('test/fixtures', ['dir/**/*', 'some-other-dir/**/*']), [
      'dir/bar.txt',
      'dir/subdir/',
+     'dir/subdir/baz.txt',
+     'dir/zzz.txt',
+     'some-other-dir/qux.txt'
+   ])
+
+   t.deepEqual(walkSync('test/fixtures', {
+     globs: ['dir/**/*', 'some-other-dir/**/*'],
+     directories: false
+   }), [
+     'dir/bar.txt',
      'dir/subdir/baz.txt',
      'dir/zzz.txt',
      'some-other-dir/qux.txt'


### PR DESCRIPTION
As it turns out, most usages within broccoli actually don't require directories. In-fact caring about directories (without files) complicates some scenarios.

Like git, broccoli is likely better off ignoring empty directories entirely.

With this option, we can now disable directories in the output. Without having to:

* rely on an the implicit protocol of trailing `/` representing a folder
* break backwards compatibility
* re-stat the resulting files to detect files vs folders vs links

*note: this only requires a minor version bump*

[edit: removed comments, because they are distracting from the existing comment chain]