### PR TITLE
[Feature] add walkSync.entries which returns objects instead of files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ array:
 ['one.txt', 'subdir/', 'subdir/two.txt']
 ```
 
+### Entries
+
+Sometimes, it is important to get additional information from a walk of a
+directory; for instance if the downstream consumer needs to stat the files we
+can leverage the stats from the walk.
+
+To accomedate, `walkSync.entries(path [, options])` is also provided, instead
+of returning a list of files and/or directories it returns an array of objects
+which correspond to a given file or directory, except with more data.
+
+```
+let {
+  type,     // 'directoy' | 'file'
+  fullPath, 
+  relativePath,
+  stat     // new fs.Stat
+} = entry;
+```
+
 Note that directories come before their contents, and have a trailing slash.
 
 Symlinks are followed.

--- a/README.md
+++ b/README.md
@@ -38,17 +38,17 @@ Sometimes, it is important to get additional information from a walk of a
 directory; for instance if the downstream consumer needs to stat the files we
 can leverage the stats from the walk.
 
-To accomedate, `walkSync.entries(path [, options])` is also provided, instead
+To accommodate, `walkSync.entries(path [, options])` is also provided, instead
 of returning a list of files and/or directories it returns an array of objects
 which correspond to a given file or directory, except with more data.
 
 ```
-let {
-  type,     // 'directoy' | 'file'
-  fullPath, 
-  relativePath,
-  stat     // new fs.Stat
-} = entry;
+entry.relativePath
+entry.mode  // => fs.statSync(fullPath).mode
+entry.size  // => fs.statSync(fullPath).size
+entry.mtime // => fs.statSync(fullPath).mtime.getTime()
+
+entry.isDirectory() // => true if directory
 ```
 
 Note that directories come before their contents, and have a trailing slash.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ array:
 ['one.txt', 'subdir/', 'subdir/two.txt']
 ```
 
+*Note: directories come before their contents, and have a trailing slash.*
+
+Symlinks are followed.
+
 ### Entries
 
 Sometimes, it is important to get additional information from a walk of a
@@ -50,10 +54,6 @@ entry.mtime // => fs.statSync(fullPath).mtime.getTime()
 
 entry.isDirectory() // => true if directory
 ```
-
-Note that directories come before their contents, and have a trailing slash.
-
-Symlinks are followed.
 
 ### Options
 

--- a/test/test.js
+++ b/test/test.js
@@ -49,34 +49,39 @@ test('walkSync', function (t) {
   })
 
   t.end()
-})
+});
+
+function byFile(obj) {
+  return obj.file;
+}
+
+function byStat(obj) {
+  return obj.stat;
+}
+
+function appearsAsDir(entry) {
+  return entry.relativePath.charAt(entry.relativePath.length - 1) === '/';
+}
 
 test('entries', function (t) {
-  function byFile(obj) {
-    return obj.file;
-  }
-
-  function byStat(obj) {
-    return obj.stat;
-  }
-
   function expectAllEntries(array) {
     array.forEach(function(entry) {
-
       if (entry.relativePath === 'symlink2') {
-        // symlink2 is a dead symlink and wont have a stat object.
-        // TODO: maybe explore a null object in place of this undefined
-        t.type(entry.stat, 'undefined');
-
+        t.assert(!entry.isDirectory());
       } else {
-        t.type(entry.stat, 'object');
 
-        t.assert(entry.stat.mtime);
-        t.assert(entry.stat.mode);
-        t.assert(entry.stat.size > -1);
+        if (appearsAsDir(entry)) {
+          t.assert(entry.isDirectory());
+        } else {
+          t.assert(!entry.isDirectory());
+        }
 
+        t.assert(entry.mtime);
+        t.assert(entry.mode);
+        t.assert(entry.size > -1);
       }
-      t.deepEqual(Object.keys(entry).sort(), ['fullPath', 'relativePath', 'stat', 'type'].sort());
+
+      t.deepEqual(Object.keys(entry).sort(), ['relativePath', 'basePath', 'size', 'mtime', 'mode'].sort());
     });
   }
 

--- a/test/test.js
+++ b/test/test.js
@@ -51,6 +51,40 @@ test('walkSync', function (t) {
   t.end()
 })
 
+test('entries', function (t) {
+  function byFile(obj) {
+    return obj.file;
+  }
+
+  function byStat(obj) {
+    return obj.stat;
+  }
+
+  function expectAllEntries(array) {
+    array.forEach(function(entry) {
+
+      if (entry.relativePath === 'symlink2') {
+        // symlink2 is a dead symlink and wont have a stat object.
+        // TODO: maybe explore a null object in place of this undefined
+        t.type(entry.stat, 'undefined');
+
+      } else {
+        t.type(entry.stat, 'object');
+
+        t.assert(entry.stat.mtime);
+        t.assert(entry.stat.mode);
+        t.assert(entry.stat.size > -1);
+
+      }
+      t.deepEqual(Object.keys(entry).sort(), ['fullPath', 'relativePath', 'stat', 'type'].sort());
+    });
+  }
+
+  expectAllEntries(walkSync.entries('test/fixtures'));
+
+  t.end();
+});
+
 test('walkSync \w matchers', function (t) {
    t.deepEqual(walkSync('test/fixtures', ['dir/bar.txt']), [
      'dir/bar.txt'


### PR DESCRIPTION
These objects contain. type, fullpath, relativePath and stats.

This is for consumers like broccoli, which now can avoid duplicate work.

@chadhietala & @stefanpenner