### PR TITLE
let node handle symlinks, since git for windows can't do it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /node_modules
 /benchmark.tmp
+test/fixtures/symlink1
+test/fixtures/symlink2

--- a/test/fixtures/symlink1
+++ b/test/fixtures/symlink1
@@ -1,1 +1,0 @@
-./some-other-dir

--- a/test/fixtures/symlink2
+++ b/test/fixtures/symlink2
@@ -1,1 +1,0 @@
-doesnotexist

--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 var tap = require('tap');
 var test = tap.test;
 var walkSync = require('../');
+var symlink = require('./utils/symlink');
 
 function captureError(fn) {
   try {
@@ -19,6 +20,10 @@ tap.Test.prototype.addAssert('matchThrows', 2, function(fn, expectedError) {
   this.equal(error.name, expectedError.name);
   this.match(error.message, expectedError.message);
 });
+
+// git for windows doesn't support symlinks, so let node handle it
+symlink('./some-other-dir', 'test/fixtures/symlink1');
+symlink('doesnotexist', 'test/fixtures/symlink2', true);
 
 test('walkSync', function (t) {
   t.deepEqual(walkSync('test/fixtures'), [

--- a/test/utils/symlink.js
+++ b/test/utils/symlink.js
@@ -1,0 +1,17 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function(destination, filePath, shouldBreakLink) {
+  var root = path.dirname(filePath);
+  var link = path.join(root, destination);
+  if (shouldBreakLink && !fs.existsSync(link)) {
+    fs.mkdirSync(link);
+  }
+  if (fs.existsSync(filePath)) {
+    fs.unlinkSync(filePath);
+  }
+  fs.symlinkSync(destination, filePath);
+  if (shouldBreakLink && fs.existsSync(link)) {
+    fs.rmdirSync(link);
+  }
+}


### PR DESCRIPTION
git for windows:
```
error: unable to create symlink xxx (Function not implemented)
```

This fixes 3 out of the 5 failing windows tests. The remaining 2 are path separator issues I'm working on.