### PR TITLE
use path.sep to maintain cross-platform

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var path = require('path');
 var MatcherCollection = require('matcher-collection');
 
 function handleOptions(_options) {
@@ -17,8 +18,8 @@ function handleOptions(_options) {
 function handleRelativePath(_relativePath) {
   if (_relativePath == null) {
     return '';
-  } else if (_relativePath.slice(-1) !== '/') {
-    return _relativePath + '/';
+  } else if (_relativePath.slice(-1) !== path.sep) {
+    return _relativePath + path.sep;
   }
 }
 
@@ -61,7 +62,7 @@ function _walkSync(baseDir, options, _relativePath) {
 
     if (stats && stats.isDirectory()) {
       if (options.directories !== false && (!m || m.match(entryRelativePath))) {
-        results.push(new Entry(entryRelativePath + '/', baseDir, stats.mode, stats.size, stats.mtime.getTime()));
+        results.push(new Entry(entryRelativePath + path.sep, baseDir, stats.mode, stats.size, stats.mtime.getTime()));
       }
       results = results.concat(_walkSync(baseDir, options, entryRelativePath));
     } else {
@@ -83,7 +84,7 @@ function Entry(relativePath, basePath, mode, size, mtime) {
 
 Object.defineProperty(Entry.prototype, 'fullPath', {
   get: function() {
-    return this.basePath + '/' + this.relativePath;
+    return this.basePath + path.sep + this.relativePath;
   }
 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,11 @@
 'use strict';
 
+var path = require('path');
 var tap = require('tap');
 var test = tap.test;
 var walkSync = require('../');
 var symlink = require('./utils/symlink');
+var normalizePathForRegex = require('./utils/normalize-path-for-regex');
 
 function captureError(fn) {
   try {
@@ -38,27 +40,27 @@ test('walkSync', function (t) {
     'symlink1/',
     'symlink1/qux.txt',
     'symlink2'
-  ]);
+  ].map(path.normalize));
 
   t.matchThrows(function() {
     walkSync('test/doesnotexist');
   }, {
     name: 'Error',
-    message: /ENOENT.* 'test\/doesnotexist/
+    message: new RegExp('ENOENT.*' + normalizePathForRegex('test/doesnotexist'))
   });
 
   t.matchThrows(function() {
     walkSync('test/fixtures/foo.txt');
   }, {
     name: 'Error',
-    message: /ENOTDIR.* 'test\/fixtures\/foo.txt/
+    message: new RegExp('ENOTDIR.*' + normalizePathForRegex('test/fixtures/foo.txt'))
   });
 
   t.end();
 });
 
 function appearsAsDir(entry) {
-  return entry.relativePath.charAt(entry.relativePath.length - 1) === '/';
+  return entry.relativePath.charAt(entry.relativePath.length - 1) === path.sep;
 }
 
 test('entries', function (t) {
@@ -95,21 +97,21 @@ test('entries', function (t) {
 test('walkSync with matchers', function (t) {
    t.deepEqual(walkSync('test/fixtures', ['dir/bar.txt']), [
      'dir/bar.txt'
-   ]);
+   ].map(path.normalize));
 
    t.deepEqual(walkSync('test/fixtures', { globs: ['dir/bar.txt'] }), [
      'dir/bar.txt'
-   ]);
+   ].map(path.normalize));
 
    t.deepEqual(walkSync('test/fixtures', ['dir/bar.txt', 'dir/zzz.txt']), [
      'dir/bar.txt',
      'dir/zzz.txt'
-   ]);
+   ].map(path.normalize));
 
    t.deepEqual(walkSync('test/fixtures', ['dir/{bar,zzz}.txt']), [
      'dir/bar.txt',
      'dir/zzz.txt'
-   ]);
+   ].map(path.normalize));
 
    t.deepEqual(walkSync('test/fixtures', ['dir/**/*', 'some-other-dir/**/*']), [
      'dir/bar.txt',
@@ -117,7 +119,7 @@ test('walkSync with matchers', function (t) {
      'dir/subdir/baz.txt',
      'dir/zzz.txt',
      'some-other-dir/qux.txt'
-   ]);
+   ].map(path.normalize));
 
    t.deepEqual(walkSync('test/fixtures', {
      globs: ['dir/**/*', 'some-other-dir/**/*'],
@@ -127,7 +129,7 @@ test('walkSync with matchers', function (t) {
      'dir/subdir/baz.txt',
      'dir/zzz.txt',
      'some-other-dir/qux.txt'
-   ]);
+   ].map(path.normalize));
 
   t.deepEqual(walkSync('test/fixtures', ['**/*.txt']), [
     'dir/bar.txt',
@@ -136,14 +138,14 @@ test('walkSync with matchers', function (t) {
     'foo.txt',
     'some-other-dir/qux.txt',
     'symlink1/qux.txt'
-  ]);
+  ].map(path.normalize));
 
   t.deepEqual(walkSync('test/fixtures', ['{dir,symlink1}/**/*.txt']), [
     'dir/bar.txt',
     'dir/subdir/baz.txt',
     'dir/zzz.txt',
     'symlink1/qux.txt'
-  ]);
+  ].map(path.normalize));
 
   t.end();
 });

--- a/test/utils/normalize-path-for-regex.js
+++ b/test/utils/normalize-path-for-regex.js
@@ -1,0 +1,5 @@
+var path = require('path');
+
+module.exports = function(filePath) {
+  return path.normalize(filePath).replace(/\\/g, '\\\\').replace(/\//g, '\\/');
+}


### PR DESCRIPTION
Fixes the remaining windows issues. The basic idea is that we accept any path format (/ or \\), but output paths in your OS's format, just like node's native path.join, path.normalize, etc.

Hopefully this can unblock the ember-cli 1.13.9 release. This PR may generate some discussion, as I think @stefanpenner may disagree with me. In my opinion, this is ready to merge.

cc @raytiley @felixrieseberg curious to hear other windows opinions if I'm barking up the wrong tree or not :stuck_out_tongue: