### PR TITLE
added tests that work in Windows CI

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,6 @@ function walkSync(baseDir, _options) {
 module.exports.entries = function entries(baseDir, _options) {
   var options = handleOptions(_options);
 
-
   return _walkSync(ensurePosix(baseDir), options);
 };
 


### PR DESCRIPTION
Windows CI wasn't testing our `ensurePosix` fix, because the input paths were posix only. This injects a normalized input path in all our `walkSync` calls, mainly for cleanliness so we don't have to update all the references in the tests.