### PR TITLE
bower_components symlink issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,9 @@ function getStat(path) {
   try {
     stat = fs.statSync(path);
   } catch(error) {
+    if (error.code == 'ELOOP') {
+      return fs.lstatSync(path);
+    }
     if (error.code !== 'ENOENT') {
       throw error;
     }


### PR DESCRIPTION
When bower_components is symlinked `fs.statSync` fails with the following error. In the error message below bower_components is symlinked to eea2ee0a78a61d4e5df0ff21f9ac4ebc3e6f6243-bower and for some reason the symlinks are nested which leads to ELOOP error. I don't know the root cause but this fixes the problem.

```
The Broccoli Plugin: [SassCompiler] failed with:
Error: ELOOP: too many symbolic links encountered, stat '/shared/agent-16/code/app/tmp/sass_compiler-input_base_path-AOToNpdw.tmp/0/bower_components/eea2ee0a78a61d4e5df0ff21f9ac4ebc3e6f6243-bower'
    at Error (native)
    at Object.fs.statSync (fs.js:844:18)
    ...
```