### PR TITLE
Add 'includeBasePath' to options so files pathes are prefixed with ba…

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var fs = require('fs');
 var MatcherCollection = require('matcher-collection');
 var ensurePosix = require('ensure-posix-path');
+var path = require('path');
 
 function handleOptions(_options) {
   var options = {};
@@ -32,7 +33,7 @@ function walkSync(baseDir, _options) {
   var mapFunct;
   if (options.includeBasePath) {
     mapFunct = function (entry) {
-      return entry.basePath + '/' + entry.relativePath;
+      return entry.basePath.split(path.sep).join('/') + '/' + entry.relativePath;
     };
   } else {
     mapFunct = function (entry) {

--- a/index.js
+++ b/index.js
@@ -29,9 +29,18 @@ module.exports = walkSync;
 function walkSync(baseDir, _options) {
   var options = handleOptions(_options);
 
-  return _walkSync(baseDir, options).map(function(entry) {
-    return entry.relativePath;
-  });
+  var mapFunct;
+  if (options.includeBasePath) {
+    mapFunct = function (entry) {
+      return entry.basePath + '/' + entry.relativePath;
+    };
+  } else {
+    mapFunct = function (entry) {
+        return entry.relativePath;
+    };
+  }
+
+  return _walkSync(baseDir, options).map(mapFunct);
 }
 
 module.exports.entries = function entries(baseDir, _options) {

--- a/test/test.js
+++ b/test/test.js
@@ -273,3 +273,13 @@ test('walksync with ignore pattern', function (t) {
 
   t.end();
 });
+
+test('walksync with includePath option', function (t) {
+  t.deepEqual(walkSync('test/fixtures/dir/subdir', {
+      includeBasePath: true
+  }), [
+      'test/fixtures/dir/subdir/baz.txt'
+  ]);
+
+  t.end();
+});


### PR DESCRIPTION
Add 'includeBasePath' to options so files pathes are prefixed with baseDir path. It simplifies applications codes where paths are absolutes.