### PR TITLE
Incorrect type info for mtime

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare namespace WalkSync {
     fullPath: string;
     mode: number;
     size: number;
-    mtime: Date;
+    mtime: number;
     isDirectory(): boolean;
     static fromStat(relativePath: string, stat: any): WalkSyncEntry;
   }


### PR DESCRIPTION
Our mtime is a number, not a Date. 

See also https://github.com/joliss/node-walk-sync/pull/13