### PR TITLE
fix: update includeBasePath example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ entry.isDirectory() // => true if directory
    *note: this flag is only for `walkSync(..)` not `walkSync.entries(..)`*
 
    ```js
-    const paths = walkSync('project', { includeBaseDir: true });
+    const paths = walkSync('project', { includeBasePath: true });
     // => ['project/one.txt', 'project/subdir/two.txt']
    ```
 


### PR DESCRIPTION
👋 @stefanpenner this is a followup to #36

The current README includes an example with a misnamed `includeBaseDir` option. This PR updates the README to include the correct `includeBasePath` option.

cc @sarahs