### PR TITLE
Adding a symlink to a file that is created with a trailing slash breaks walk-sync.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,10 @@
 /benchmark.tmp
 test/fixtures/symlink1
 test/fixtures/symlink2
+test/fixtures/symlink3
+test/fixtures/bar
 test/fixtures/contains-cycle/symlink2
+test/fixtures/contains-cycle/is-cycle
 .vscode/
 **/*.js
 **/*.d.ts

--- a/index.ts
+++ b/index.ts
@@ -27,9 +27,10 @@ function getStat(path: string) {
   try {
     return fs.statSync(path);
   } catch(error) {
-    if (error.code !== 'ENOENT') {
-      throw error;
+    if (error !== null && typeof error === 'object' && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
+      return;
     }
+    throw error;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
     "index.d.ts"
   ],
   "dependencies": {
+    "@types/minimatch": "^3.0.3",
     "ensure-posix-path": "^1.1.0",
-    "matcher-collection": "^1.1.1",
-    "@types/minimatch": "^3.0.3"
+    "matcher-collection": "^1.1.1"
   },
   "devDependencies": {
     "@types/node": "^10.12.21",
+    "glob": "^7.1.4",
     "rimraf": "^2.4.3",
     "tap": "^1.0.0",
     "typescript": "~3.3.1"

--- a/test/test.ts
+++ b/test/test.ts
@@ -61,6 +61,7 @@ test('walkSync', function (t: any) {
   var entries = walkSync('test/fixtures');
 
   t.deepEqual(entries, [
+    'bar',
     'contains-cycle/',
     'contains-cycle/.gitkeep',
     'contains-cycle/is-cycle/',
@@ -76,7 +77,8 @@ test('walkSync', function (t: any) {
     'some-other-dir/qux.txt',
     'symlink1/',
     'symlink1/qux.txt',
-    'symlink2'
+    'symlink2',
+    'symlink3'
   ].filter(Boolean));
 
   t.deepEqual(entries, entries.slice().sort());
@@ -111,6 +113,10 @@ test('entries', function (t: any) {
       };
     }),
       [
+      {
+        basePath: 'test/fixtures',
+        fullPath: 'test/fixtures/bar'
+      },
       {
         basePath: 'test/fixtures',
         fullPath: 'test/fixtures/contains-cycle/'
@@ -174,11 +180,15 @@ test('entries', function (t: any) {
       {
         basePath: 'test/fixtures',
         fullPath: 'test/fixtures/symlink2'
+      },
+      {
+        basePath: 'test/fixtures',
+        fullPath: 'test/fixtures/symlink3'
       }
     ]);
 
     array.forEach(function(entry) {
-      if (entry.relativePath === 'symlink2') {
+      if (entry.relativePath === 'symlink2' || entry.relativePath === 'symlink3') {
         t.assert(!entry.isDirectory());
       } else {
 
@@ -266,6 +276,7 @@ test('walksync with ignore pattern', function (t: any) {
   t.deepEqual(walkSync('test/fixtures', {
     ignore: ['dir']
   }), [
+    'bar',
     'contains-cycle/',
     'contains-cycle/.gitkeep',
     'contains-cycle/is-cycle/',
@@ -276,12 +287,14 @@ test('walksync with ignore pattern', function (t: any) {
     'some-other-dir/qux.txt',
     'symlink1/',
     'symlink1/qux.txt',
-    'symlink2'
+    'symlink2',
+    'symlink3'
   ]);
 
   t.deepEqual(walkSync('test/fixtures', {
     ignore: ['**/subdir']
   }), [
+    'bar',
     'contains-cycle/',
     'contains-cycle/.gitkeep',
     'contains-cycle/is-cycle/',
@@ -295,7 +308,8 @@ test('walksync with ignore pattern', function (t: any) {
     'some-other-dir/qux.txt',
     'symlink1/',
     'symlink1/qux.txt',
-    'symlink2'
+    'symlink2',
+    'symlink3'
   ]);
 
   t.deepEqual(walkSync('test/fixtures', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -227,11 +227,6 @@ decamelize@^1.1.1:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
-deep-equal@*:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
-  integrity sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=
-
 deep-is@~0.1.2:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -415,6 +410,18 @@ glob@^7.0.5, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.4"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+glob@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
+  integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"


### PR DESCRIPTION
This addition to the test suite illustrates the issue. (Note that there are no tests added, so this PR is really just a way to reproduce the problem.)

I ran into this trying to run the ember-native-class-codemod with the error captured here: https://github.com/ember-codemods/ember-native-class-codemod/issues/138