### PR TITLE
Adding new option 'globOptions'

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ entry.isDirectory() // => true if directory
     const paths = walkSync('project', { fs });
     // => ['aDir/', 'aDir/aFile']
    ```
+  
+* `globOptions`: Any options for [Minimatch](https://www.npmjs.com/package/minimatch) that will be applied to both `globs` and `ignore`
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ entry.isDirectory() // => true if directory
     // => ['one.txt']
     ```
 
+    As an alternative to string globs, you can pass an array of precompiled
+    [`minimatch.Minimatch`](https://github.com/isaacs/minimatch#minimatch-class)
+    instances. This is faster and allows to specify your own globbing options.
+
 * `includeBasePath` (default: false): Pass `true` to include the basePath in the output.
    *note: this flag is only for `walkSync(..)` not `walkSync.entries(..)`*
 
@@ -105,7 +109,9 @@ entry.isDirectory() // => true if directory
     // => ['aDir/', 'aDir/aFile']
    ```
   
-* `globOptions`: Any options for [Minimatch](https://www.npmjs.com/package/minimatch) that will be applied to both `globs` and `ignore`
+* `globOptions`: Pass any options for [Minimatch](https://www.npmjs.com/package/minimatch) that will be applied to all items in `globs` and `ignore` that are strings. 
+  
+  If items in `globs` or `ignore` are instances of `minimatch.Minimatch`, the `globOptions` will not be applied.
 
 ## Background
 

--- a/index.ts
+++ b/index.ts
@@ -101,7 +101,6 @@ function applyGlobOptions(globs: (string|IMinimatch)[] | undefined, options: Min
       return new Minimatch(glob, options);
     }
 
-    glob.options = {...glob.options, ...options};
     return glob;
   })
 }

--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ import fsNode = require('fs');
 import * as MatcherCollection from 'matcher-collection';
 import ensurePosix = require('ensure-posix-path');
 import path = require('path');
-import { IMinimatch } from 'minimatch';
+import { IMinimatch, IOptions as MinimatchOptions, Minimatch } from 'minimatch';
 
 type Optionalize<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
@@ -49,7 +49,8 @@ namespace walkSync {
       globs?: (string|IMinimatch)[],
       ignore?: (string|IMinimatch)[],
       directories?: boolean,
-      fs: typeof fsNode
+      fs: typeof fsNode,
+      globOptions?: MinimatchOptions,
   }
 
   export class Entry {
@@ -94,6 +95,17 @@ function handleOptions(_options?: Optionalize<walkSync.Options, 'fs'> | (string|
   return options as  walkSync.Options;
 }
 
+function applyGlobOptions(globs: (string|IMinimatch)[] | undefined, options: MinimatchOptions) { 
+  return globs?.map(glob => { 
+    if (typeof glob === 'string') { 
+      return new Minimatch(glob, options);
+    }
+
+    glob.options = {...glob.options, ...options};
+    return glob;
+  })
+}
+
 function handleRelativePath(_relativePath: string | null) {
   if (_relativePath == null) {
     return '';
@@ -130,8 +142,9 @@ function _walkSync(baseDir: string, options: walkSync.Options, _relativePath: st
   }
 
   try {
-    const globs = options.globs;
-    const ignorePatterns = options.ignore;
+    const globOptions = options.globOptions;
+    const ignorePatterns = (isDefined(globOptions)) ? applyGlobOptions(options.ignore, globOptions) : options.ignore;
+    const globs = (isDefined(globOptions)) ? applyGlobOptions(options.globs, globOptions) : options.globs;
     let globMatcher;
     let ignoreMatcher: undefined | InstanceType<typeof MatcherCollection>;
     let results: walkSync.Entry[] = [];

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@types/minimatch": "^3.0.3",
     "ensure-posix-path": "^1.1.0",
-    "matcher-collection": "^2.0.0"
+    "matcher-collection": "^2.0.0",
+    "minimatch": "^3.0.4"
   },
   "devDependencies": {
     "@types/jest": "^24.0.15",

--- a/test/fixtures/contains-cycle/is-cycle
+++ b/test/fixtures/contains-cycle/is-cycle
@@ -1,1 +1,1 @@
-/Users/mattpenrice/dev/org-repo/packages/node-walk-sync-master-master/test/fixtures/contains-cycle/
+/Users/ckessler/node-walk-sync/test/fixtures/contains-cycle/

--- a/test/test.ts
+++ b/test/test.ts
@@ -63,6 +63,8 @@ test('walkSync', function () {
     'contains-cycle/.gitkeep',
     'contains-cycle/is-cycle/',
     'dir/',
+    'dir/.bin/',
+    'dir/.bin/dotty.txt',
     'dir/bar.txt',
     'dir/subdir/',
     'dir/subdir/baz.txt',
@@ -96,7 +98,7 @@ test('entries', function () {
         fullPath: entry.fullPath
       };
     })).toStrictEqual(
-      [
+      [ 
       {
         basePath: 'test/fixtures',
         fullPath: 'test/fixtures/bar'
@@ -117,6 +119,14 @@ test('entries', function () {
         basePath: 'test/fixtures',
         fullPath: 'test/fixtures/dir/'
       },
+      {
+        basePath: 'test/fixtures',
+        fullPath: 'test/fixtures/dir/.bin/'
+      },
+      {
+        basePath: 'test/fixtures',
+        fullPath: 'test/fixtures/dir/.bin/dotty.txt'
+      }, 
       {
         basePath: 'test/fixtures',
         fullPath: 'test/fixtures/dir/bar.txt'
@@ -275,6 +285,8 @@ test('walksync with ignore pattern', function () {
     'contains-cycle/.gitkeep',
     'contains-cycle/is-cycle/',
     'dir/',
+    'dir/.bin/',
+    'dir/.bin/dotty.txt',
     'dir/bar.txt',
     'dir/zzz.txt',
     'foo.txt',
@@ -304,6 +316,31 @@ test('walksync with includePath option', function () {
   })).toStrictEqual([
       'test/fixtures/dir/subdir/baz.txt'
   ]);
+});
+
+describe('walksync applies globOptions', function() {
+  it('does not find files under dot directories by default', function () {
+    expect(walkSync('test/fixtures', {
+        globs: ['dir/**/*']
+    })).not.toContain('dir/.bin/dotty.txt');
+  });
+  it('finds files under dot directories if dot is set', function () {
+    expect(walkSync('test/fixtures', {
+      globs: ['dir/**/*'],
+      globOptions: { dot: true }
+    })).toContain('dir/.bin/dotty.txt');
+  });
+  it('does not ignores files under dot directories by default', function () {
+    expect(walkSync('test/fixtures', {
+        ignore: ['dir/**/*'],
+    })).toContain('dir/.bin/dotty.txt');
+  });
+  it('ignores files under dot directories if dot is set', function () {
+    expect(walkSync('test/fixtures', {
+        ignore: ['dir/**/*'],
+        globOptions: { dot: true }
+    })).not.toContain('dir/.bin/dotty.txt');
+  });
 });
 
 describe('walksync with alternate fs option (memfs)', function() {

--- a/test/test.ts
+++ b/test/test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as walkSync from '../';
 import * as fs from 'fs';
 import {Volume, createFsFromVolume} from 'memfs'
+import { Minimatch } from 'minimatch';
 
 function symlink(destination: string, filePath: string, shouldBreakLink?: boolean) {
   const  root = path.dirname(filePath);
@@ -324,20 +325,30 @@ describe('walksync applies globOptions', function() {
         globs: ['dir/**/*']
     })).not.toContain('dir/.bin/dotty.txt');
   });
+
   it('finds files under dot directories if dot is set', function () {
     expect(walkSync('test/fixtures', {
       globs: ['dir/**/*'],
       globOptions: { dot: true }
     })).toContain('dir/.bin/dotty.txt');
   });
+
   it('does not ignores files under dot directories by default', function () {
     expect(walkSync('test/fixtures', {
         ignore: ['dir/**/*'],
     })).toContain('dir/.bin/dotty.txt');
   });
+
   it('ignores files under dot directories if dot is set', function () {
     expect(walkSync('test/fixtures', {
         ignore: ['dir/**/*'],
+        globOptions: { dot: true }
+    })).not.toContain('dir/.bin/dotty.txt');
+  });
+
+  it('doesnt apply globOptions if globs are instances of minimatch', function () {
+    expect(walkSync('test/fixtures', {
+        globs: [new Minimatch('dir/**/*')],
         globOptions: { dot: true }
     })).not.toContain('dir/.bin/dotty.txt');
   });


### PR DESCRIPTION
`globOptions: { <any options for minimatch> }`

You can pass in globOptions and they will be applied to all of the globs being passed in via `globs` or `ignore`. This is a nice way to override some of minimatch's weirder default options (such as `dot`) without having to create instances of minimatches when using walksync.