### PR TITLE
move @types/minimatch to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,13 +17,13 @@
     "dist/"
   ],
   "dependencies": {
-    "@types/minimatch": "^5.1.2",
     "ensure-posix-path": "^1.1.1",
     "matcher-collection": "^2.0.1",
     "minimatch": "^10.0.3"
   },
   "devDependencies": {
     "@types/jest": "^30.0.0",
+    "@types/minimatch": "^5.1.2",
     "@types/node": "^24.3.0",
     "glob": "^11.0.3",
     "jest": "^30.1.3",


### PR DESCRIPTION
This removes the need for JS-only consumers of this library to install types packages that they don't need 👍 